### PR TITLE
Added clearer TFCond: TFCond_HealingDebuff

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -195,7 +195,8 @@ enum TFCond
 	TFCond_KnockedIntoAir,
 	TFCond_CompetitiveWinner,
 	TFCond_CompetitiveLoser,
-	TFCond_NoTaunting,
+	TFCond_NoTaunting, // 118
+	TFCond_HealingDebuff=118,
 };
 
 const float TFCondDuration_Infinite = -1.0;


### PR DESCRIPTION
This condition is activated whenever a pyro does direct fire damage to another player. **TFCond_NoTaunting** was probably repurposed by Valve leading up to the last major update. I purpose **TFCond_HealingDebuff**, straight from the game's strings.
